### PR TITLE
Add DAQ library import tests

### DIFF
--- a/test_daqs.py
+++ b/test_daqs.py
@@ -1,0 +1,16 @@
+import importlib
+
+modules = [
+    "labjack",
+    "labjack.ljm",
+    "mcculw",
+    "nidaqmx",
+]
+
+for name in modules:
+    try:
+        importlib.import_module(name)
+        status = "[OK]"
+    except Exception:
+        status = "[FAIL]"
+    print(f"{name}: {status}")


### PR DESCRIPTION
## Summary
- add `test_daqs.py` script to check optional DAQ libraries

## Testing
- `python test_daqs.py`
- `python -m py_compile test_daqs.py`


------
https://chatgpt.com/codex/tasks/task_e_68c36838968883228f029afcf463b4f7