### PR TITLE
Add NI-DAQmx device detection script

### DIFF
--- a/test_nidaqmx_devices.py
+++ b/test_nidaqmx_devices.py
@@ -1,0 +1,10 @@
+from nidaqmx.system import System
+
+system = System.local()
+devices = list(system.devices)
+
+if not devices:
+    print("No NI‑DAQmx devices detected.")
+else:
+    for dev in devices:
+        print(f"{dev.name}: {dev.product_type}")


### PR DESCRIPTION
## Summary
- Add `test_nidaqmx_devices.py` to enumerate NI-DAQmx devices and print their product types

## Testing
- `python test_daqs.py`
- `python test_nidaqmx_devices.py` *(fails: DaqNotFoundError: Could not find an installation of NI-DAQmx)*

------
https://chatgpt.com/codex/tasks/task_e_68c36c3bdd188322b1a0e04af5f058e5