### PR TITLE
Add test to print NI-DAQmx device names

### DIFF
--- a/test_device_names.py
+++ b/test_device_names.py
@@ -1,0 +1,6 @@
+import nidaqmx
+from nidaqmx.system import System
+
+system = System.local()
+for d in system.devices:
+    print(d.name, d.product_type)


### PR DESCRIPTION
## Summary
- add simple script test to list NI-DAQmx device names and product types

## Testing
- `pytest -q` *(fails: nidaqmx.errors.DaqNotFoundError: Could not find an installation of NI-DAQmx)*

------
https://chatgpt.com/codex/tasks/task_e_68c36f6f3b3c8322bdbe4efca6389d21