### PR TITLE
refactor: centralize YAML loading and device utilities

### DIFF
--- a/daq/daqI.py
+++ b/daq/daqI.py
@@ -32,7 +32,8 @@ from typing import Any, Dict
 import nidaqmx
 from nidaqmx.constants import TerminalConfiguration
 import numpy as np
-import yaml
+
+from .utils import load_yaml
 
 
 @dataclass
@@ -73,8 +74,7 @@ def load_config(path: str) -> Dict[str, Any]:
         ``terminal``.
     """
 
-    with open(path, "r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh) or {}
+    data = load_yaml(path)
 
     device = data.get("device")
     channels = data.get("channels")

--- a/daq/daqO.py
+++ b/daq/daqO.py
@@ -32,7 +32,8 @@ from dataclasses import dataclass
 from typing import Any, Dict
 
 import nidaqmx
-import yaml
+
+from .utils import load_yaml
 
 
 @dataclass
@@ -71,8 +72,7 @@ def load_config(path: str) -> Dict[str, Any]:
         optional ``seed``.
     """
 
-    with open(path, "r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh) or {}
+    data = load_yaml(path)
 
     device = data.get("device")
     channels = data.get("channels")

--- a/daq/utils.py
+++ b/daq/utils.py
@@ -1,0 +1,67 @@
+"""Utility helpers for NI-DAQmx modules.
+
+This module centralises small helper functions that are shared between
+the :mod:`daq.daqI` and :mod:`daq.daqO` modules.  Placing them here keeps the
+other modules focused on their core logic and avoids repetition.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+try:  # pragma: no cover - nidaqmx might not be installed during tests
+    from nidaqmx.system import System
+except Exception:  # noqa: BLE001 - optional dependency
+    System = None  # type: ignore[assignment]
+
+
+def load_yaml(path: str | Path) -> Dict[str, Any]:
+    """Load a YAML file from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Path to the YAML configuration file.
+
+    Returns
+    -------
+    dict
+        Parsed YAML content.  If the file is empty an empty dictionary is
+        returned instead.
+    """
+
+    with open(Path(path), "r", encoding="utf-8") as fh:
+        data: Dict[str, Any] | None = yaml.safe_load(fh)
+    return data or {}
+
+
+def list_devices() -> List[str]:
+    """Return names of detected NI-DAQmx devices.
+
+    The function attempts to query the local NI-DAQmx system for connected
+    devices.  If the :mod:`nidaqmx` package is unavailable or an error occurs
+    during discovery an empty list is returned.
+    """
+
+    if System is None:
+        return []
+
+    try:
+        system = System.local()
+        return [dev.name for dev in system.devices]
+    except Exception:  # noqa: BLE001 - best effort device discovery
+        return []
+
+
+def first_device() -> Optional[str]:
+    """Return the first detected NI-DAQmx device name if available."""
+
+    devices = list_devices()
+    return devices[0] if devices else None
+
+
+__all__ = ["load_yaml", "list_devices", "first_device"]
+


### PR DESCRIPTION
## Summary
- add `daq.utils` with shared YAML loader and device helpers
- refactor `daqI` and `daqO` to reuse `load_yaml`

## Testing
- `python -m pytest` *(fails: Could not find an installation of NI-DAQmx)*

------
https://chatgpt.com/codex/tasks/task_e_68c38cf59b748322946e38ede0a3cb7c