### PR TITLE
Add shared YAML-backed config parsing for DAQ modules

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,17 @@
+daqI:
+  device: Dev1
+  channels:
+    - Dev1/ai0
+    - Dev1/ai1
+  freq: 10
+  averages: 5
+  terminal: RSE
+daqO:
+  device: Dev1
+  channels:
+    - Dev1/ao0
+    - Dev1/ao1
+  low: 0.0
+  high: 3.0
+  interval: 0.5
+  seed: 1234


### PR DESCRIPTION
## Summary
- add configurable `config.yml` with distinct `daqI` and `daqO` sections
- centralize argument parsing with new `parse_args_with_config` helper
- enable both DAQ helpers to merge CLI overrides with YAML defaults

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: Could not find an installation of NI-DAQmx)*

------
https://chatgpt.com/codex/tasks/task_e_68c38defc39c83228cdc632a8dc26689