### PR TITLE
Support nested daqO config section

### DIFF
--- a/daqio/daqO.py
+++ b/daqio/daqO.py
@@ -34,7 +34,8 @@ from .config import load_yaml
 def load_config(path: str) -> dict:
     """Load analog-output configuration from ``path``.
 
-    The YAML file may contain the following keys:
+    The YAML file may contain the following keys, either at the top level or
+    nested under a ``daqO`` section:
 
     ``device`` (str)
         NI-DAQmx device name, e.g. ``Dev1`` or ``cDAQ1Mod1``.
@@ -60,13 +61,17 @@ def load_config(path: str) -> dict:
     """
 
     data = load_yaml(path)
+    cfg = data
+    required = {"device", "interval", "low", "high"}
+    if not required.issubset(cfg.keys()) and "daqO" in data:
+        cfg = data["daqO"]
     return {
-        "device": data.get("device"),
-        "channels": data.get("channels"),
-        "interval": data.get("interval"),
-        "low": data.get("low"),
-        "high": data.get("high"),
-        "seed": data.get("seed"),
+        "device": cfg.get("device"),
+        "channels": cfg.get("channels"),
+        "interval": cfg.get("interval"),
+        "low": cfg.get("low"),
+        "high": cfg.get("high"),
+        "seed": cfg.get("seed"),
     }
 
 

--- a/tests/test_daqo_config.py
+++ b/tests/test_daqo_config.py
@@ -1,0 +1,60 @@
+"""Tests for :func:`daqio.daqO.load_config`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from daqio.daqO import load_config
+
+
+def _write_yaml(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "config.yml"
+    path.write_text(content)
+    return path
+
+
+def test_load_config_flat(tmp_path):
+    path = _write_yaml(
+        tmp_path,
+        """
+device: Dev1
+channels:
+  - Dev1/ao0
+  - Dev1/ao1
+interval: 0.5
+low: -5
+high: 5
+seed: 123
+""",
+    )
+    cfg = load_config(path)
+    assert cfg["device"] == "Dev1"
+    assert cfg["channels"] == ["Dev1/ao0", "Dev1/ao1"]
+    assert cfg["interval"] == 0.5
+    assert cfg["low"] == -5
+    assert cfg["high"] == 5
+    assert cfg["seed"] == 123
+
+
+def test_load_config_nested(tmp_path):
+    path = _write_yaml(
+        tmp_path,
+        """
+daqO:
+  device: Dev1
+  channels:
+    - Dev1/ao0
+    - Dev1/ao1
+  interval: 0.5
+  low: -5
+  high: 5
+  seed: 123
+""",
+    )
+    cfg = load_config(path)
+    assert cfg["device"] == "Dev1"
+    assert cfg["channels"] == ["Dev1/ao0", "Dev1/ao1"]
+    assert cfg["interval"] == 0.5
+    assert cfg["low"] == -5
+    assert cfg["high"] == 5
+    assert cfg["seed"] == 123


### PR DESCRIPTION
## Summary
- allow `daqio.daqO.load_config` to read configuration from top level or `daqO` section in YAML
- add tests covering both flat and nested YAML layouts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c490625be08322ada52a3e934fe7e5