### PR TITLE
feat: add async publisher for analog output

### DIFF
--- a/configs/daqO_output.yml
+++ b/configs/daqO_output.yml
@@ -1,0 +1,6 @@
+timestamp_format: "%Y-%m-%d %H:%M:%S.%f"
+csv_path: ao_output.csv
+columns:
+  - timestamp
+  - cDAQ1Mod1/ao0
+  - cDAQ1Mod1/ao1

--- a/daqio/publisher.py
+++ b/daqio/publisher.py
@@ -1,0 +1,44 @@
+import asyncio
+from pathlib import Path
+import csv
+from typing import Dict, List
+
+_ao_queue: asyncio.Queue | None = None
+
+
+def _get_queue() -> asyncio.Queue:
+    global _ao_queue
+    if _ao_queue is None:
+        _ao_queue = asyncio.Queue()
+    return _ao_queue
+
+
+async def publish_ao(data: Dict) -> None:
+    """Publish analog-output data to the queue."""
+    await _get_queue().put(data)
+
+
+async def _ao_consumer(csv_path: str, columns: List[str]) -> None:
+    queue = _get_queue()
+    path = Path(csv_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=columns)
+        writer.writeheader()
+        while True:
+            item = await queue.get()
+            row = {}
+            for col in columns:
+                if col == "timestamp":
+                    row[col] = item.get("timestamp")
+                else:
+                    row[col] = item.get("channel_values", {}).get(col)
+            writer.writerow(row)
+            fh.flush()
+            queue.task_done()
+
+
+def start_ao_consumer(csv_path: str, columns: List[str]) -> asyncio.Task:
+    """Start background task writing queue entries to CSV."""
+    loop = asyncio.get_running_loop()
+    return loop.create_task(_ao_consumer(csv_path, columns))

--- a/test_ao_random.py
+++ b/test_ao_random.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 from daqio.daqO import write_random
 
 
@@ -9,7 +10,9 @@ def main(dev, interval_s, low, high, seed, channels=None):
     reused by the command-line helper as well as tests.
     """
 
-    write_random(dev, interval_s, low, high, seed=seed, channels=channels)
+    asyncio.run(
+        write_random(dev, interval_s, low, high, seed=seed, channels=channels)
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add configuration for AO CSV output
- publish analog-output readings via async queue and consumer
- drive daqO using timestamp formatting and background writer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4bac955348322a8947a3b9dd993c3