### PR TITLE
Add analog input publisher and consumer support

### DIFF
--- a/configs/daqI_output.yml
+++ b/configs/daqI_output.yml
@@ -1,0 +1,6 @@
+timestamp_format: "%Y-%m-%d %H:%M:%S.%f"
+csv_path: ai_output.csv
+columns:
+  - timestamp
+  - Dev1/ai0
+  - Dev1/ai1

--- a/daqio/publisher.py
+++ b/daqio/publisher.py
@@ -4,22 +4,37 @@ import csv
 from typing import Dict, List
 
 _ao_queue: asyncio.Queue | None = None
+_ai_queue: asyncio.Queue | None = None
 
 
-def _get_queue() -> asyncio.Queue:
+def _get_ao_queue() -> asyncio.Queue:
+    """Return the singleton queue for analog-output messages."""
     global _ao_queue
     if _ao_queue is None:
         _ao_queue = asyncio.Queue()
     return _ao_queue
 
 
+def _get_ai_queue() -> asyncio.Queue:
+    """Return the singleton queue for analog-input messages."""
+    global _ai_queue
+    if _ai_queue is None:
+        _ai_queue = asyncio.Queue()
+    return _ai_queue
+
+
 async def publish_ao(data: Dict) -> None:
     """Publish analog-output data to the queue."""
-    await _get_queue().put(data)
+    await _get_ao_queue().put(data)
+
+
+async def publish_ai(result: Dict) -> None:
+    """Publish analog-input averaging results to the queue."""
+    await _get_ai_queue().put(result)
 
 
 async def _ao_consumer(csv_path: str, columns: List[str]) -> None:
-    queue = _get_queue()
+    queue = _get_ao_queue()
     path = Path(csv_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", newline="", encoding="utf-8") as fh:
@@ -38,7 +53,33 @@ async def _ao_consumer(csv_path: str, columns: List[str]) -> None:
             queue.task_done()
 
 
+async def _ai_consumer(csv_path: str, columns: List[str]) -> None:
+    queue = _get_ai_queue()
+    path = Path(csv_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=columns)
+        writer.writeheader()
+        while True:
+            item = await queue.get()
+            row = {}
+            for col in columns:
+                if col == "timestamp":
+                    row[col] = item.get("timestamp")
+                else:
+                    row[col] = item.get("results", {}).get(col)
+            writer.writerow(row)
+            fh.flush()
+            queue.task_done()
+
+
 def start_ao_consumer(csv_path: str, columns: List[str]) -> asyncio.Task:
     """Start background task writing queue entries to CSV."""
     loop = asyncio.get_running_loop()
     return loop.create_task(_ao_consumer(csv_path, columns))
+
+
+def start_ai_consumer(csv_path: str, columns: List[str]) -> asyncio.Task:
+    """Start background task writing AI queue entries to CSV."""
+    loop = asyncio.get_running_loop()
+    return loop.create_task(_ai_consumer(csv_path, columns))

--- a/tests/test_publisher_ai.py
+++ b/tests/test_publisher_ai.py
@@ -1,0 +1,53 @@
+import asyncio
+import contextlib
+from pathlib import Path
+
+import pytest
+
+from daqio import publisher
+import daqio.daqI as daqI
+from daqio.daqI import read_average
+
+
+async def _run_consumer(tmp_path: Path):
+    csv_file = tmp_path / "ai.csv"
+    columns = ["timestamp", "c1", "c2"]
+    task = publisher.start_ai_consumer(str(csv_file), columns)
+    payload = {"timestamp": "t0", "results": {"c1": 1, "c2": 2}}
+    await publisher.publish_ai(payload)
+    await publisher._get_ai_queue().join()
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    return csv_file
+
+
+def test_ai_consumer_writes_csv(tmp_path):
+    csv_file = asyncio.run(_run_consumer(tmp_path))
+    lines = csv_file.read_text().splitlines()
+    assert lines[0] == "timestamp,c1,c2"
+    assert lines[1] == "t0,1,2"
+
+
+class DummyTask:
+    def __init__(self, values):
+        self._values = values
+
+    def read(self):
+        return self._values
+
+
+def test_read_average_publish(monkeypatch):
+    captured = {}
+
+    async def fake_publish(data):
+        captured["data"] = data
+
+    monkeypatch.setattr(daqI, "publish_ai", fake_publish)
+    monkeypatch.setattr(daqI, "load_yaml", lambda path: {"timestamp_format": "%Y"})
+    monkeypatch.setattr(daqI.time, "sleep", lambda s: None)
+    cfg = {"freq": 1.0, "averages": 1, "channels": ["c1", "c2"]}
+    task = DummyTask([1.0, 2.0])
+    read_average(task, cfg)
+    assert captured["data"]["results"] == {"c1": 1.0, "c2": 2.0}
+    assert captured["data"]["timestamp"].isdigit()


### PR DESCRIPTION
## Summary
- add `daqI_output.yml` for configuring AI CSV output
- implement `publish_ai` and AI CSV consumer utilities
- publish averaged AI results with timestamp in `read_average`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4bf290ab883229b557f8b939f729f