### PR TITLE
Add output config helper and refactor publishers

### DIFF
--- a/daqio/config.py
+++ b/daqio/config.py
@@ -40,6 +40,52 @@ def load_yaml(path: str | Path) -> Dict[str, Any]:
     return data or {}
 
 
+def load_output_config(path: str | Path) -> tuple[str, str, List[str]]:
+    """Load and validate output configuration.
+
+    The configuration file may define the following optional keys:
+
+    ``timestamp_format``
+        ``datetime.strftime``-compatible format string.  Defaults to
+        ``"%Y-%m-%d %H:%M:%S.%f"``.
+    ``csv_path``
+        Output CSV file path.  Defaults to ``"output.csv"``.
+    ``columns``
+        List of column names for the CSV file.  Defaults to ``["timestamp"]``.
+
+    Parameters
+    ----------
+    path:
+        Path to the YAML configuration file.
+
+    Returns
+    -------
+    tuple
+        ``(timestamp_format, csv_path, columns)``
+
+    Raises
+    ------
+    ValueError
+        If ``csv_path`` is not a string or ``columns`` is not a
+        non-empty list of strings.
+    """
+
+    data = load_yaml(path)
+
+    ts_fmt = data.get("timestamp_format", "%Y-%m-%d %H:%M:%S.%f")
+    csv_path = data.get("csv_path", "output.csv")
+    if not isinstance(csv_path, str):
+        raise ValueError("'csv_path' must be a string")
+
+    columns = data.get("columns", ["timestamp"])
+    if not isinstance(columns, list) or not columns:
+        raise ValueError("'columns' must be a non-empty list")
+    if not all(isinstance(col, str) for col in columns):
+        raise ValueError("All column names must be strings")
+
+    return ts_fmt, csv_path, columns
+
+
 def list_devices() -> List[str]:
     """Return names of detected NI-DAQmx devices.
 
@@ -123,6 +169,7 @@ def parse_args_with_config(
 
 __all__ = [
     "load_yaml",
+    "load_output_config",
     "list_devices",
     "first_device",
     "parse_args_with_config",

--- a/daqio/daqO.py
+++ b/daqio/daqO.py
@@ -26,7 +26,7 @@ import numpy as np
 import nidaqmx
 from nidaqmx.system import System
 
-from .config import load_yaml
+from .config import load_yaml, load_output_config
 from .publisher import publish_ao, start_ao_consumer
 
 
@@ -138,10 +138,9 @@ async def write_random(
         if output_config
         else Path(__file__).resolve().parent.parent / "configs" / "daqO_output.yml"
     )
-    out_cfg = load_yaml(cfg_path)
-    ts_format = out_cfg.get("timestamp_format", "%Y-%m-%d %H:%M:%S.%f")
-    csv_path = out_cfg.get("csv_path", "ao_output.csv")
-    columns = out_cfg.get("columns", ["timestamp"] + ao_channels)
+    ts_format, csv_path, columns = load_output_config(cfg_path)
+    if columns == ["timestamp"]:
+        columns = ["timestamp", *ao_channels]
 
     consumer_task = start_ao_consumer(csv_path, columns)
 

--- a/tests/test_publisher_ai.py
+++ b/tests/test_publisher_ai.py
@@ -44,7 +44,9 @@ def test_read_average_publish(monkeypatch):
         captured["data"] = data
 
     monkeypatch.setattr(daqI, "publish_ai", fake_publish)
-    monkeypatch.setattr(daqI, "load_yaml", lambda path: {"timestamp_format": "%Y"})
+    monkeypatch.setattr(
+        daqI, "load_output_config", lambda path: ("%Y", "out.csv", ["timestamp", "c1", "c2"])
+    )
     monkeypatch.setattr(daqI.time, "sleep", lambda s: None)
     cfg = {"freq": 1.0, "averages": 1, "channels": ["c1", "c2"]}
     task = DummyTask([1.0, 2.0])


### PR DESCRIPTION
## Summary
- add `load_output_config` for timestamp/csv/column settings with defaults and validation
- refactor analog input and output publishers to use the helper during initialization
- adjust tests for the new configuration loader

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4c0875fbc832283d6adf9db802b19