### PR TITLE
Use YAML loader for async IO example config

### DIFF
--- a/IOasyncExample.py
+++ b/IOasyncExample.py
@@ -2,6 +2,7 @@ import asyncio
 
 from daqio.daqO import write_random
 from daqio.daqI import load_config, setup_task, read_average
+from daqio.config import load_yaml
 from daqio import publisher
 
 
@@ -22,7 +23,7 @@ async def queue_reader(q: asyncio.Queue, label: str):
 
 
 async def main():
-    cfg = load_config("configs/config_test.yml")
+    cfg = load_config(load_yaml("configs/config_test.yml")["daqI"])
 
     # background writers to CSV
     ao_writer = publisher.start_ao_consumer("ao.csv", ["timestamp", *cfg["channels"]])


### PR DESCRIPTION
## Summary
- Load configuration for IOasyncExample from YAML using daqio.config helper
- Import `load_yaml` for clearer config loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d82545c4832295db6311ce7d5e68