### PR TITLE
Clarify separation of daqI and daqO configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,20 @@ The `daqio` package provides lightweight helpers for working with NI-DAQmx
 analog channels. It requires the NI‑DAQmx runtime and the Python `nidaqmx`
 package to be installed. Sample configuration files live under `configs/`.
 
+Configurations are split into `daqI` (analog input) and `daqO` (analog output)
+sections. `daqI` blocks are **only** for inputs; `daqO` blocks are the sole
+safe source for outputs. Mixing these sections can raise NI‑DAQmx `I/O type`
+errors or drive unintended channels. `IOasyncExample.py` demonstrates loading
+each section separately when performing simultaneous input and output.
+
 ### Analog input (`daqio/daqI.py`)
 
 `daqio/daqI.py` reads one or more analog-input channels and prints the average
 voltage per channel. Configuration is supplied via YAML and must define the
 device name, channel list, sample frequency and number of averages; the
-terminal configuration is optional【F:daqio/daqI.py†L1-L22】【F:daqio/daqI.py†L55-L76】.
+terminal configuration is optional【F:daqio/daqI.py†L1-L26】【F:daqio/daqI.py†L66-L74】.
+Use only the `daqI` section for these settings; sourcing channel lists from
+`daqO` may cause NI‑DAQmx `I/O type` errors or unintended output.
 
 Example configuration:
 
@@ -114,7 +122,9 @@ options.
 `daqio/daqO.py` continuously drives analog-output channels with random voltages
 generated within a user-specified range. Its YAML configuration accepts the
 device name, optional channel list, update interval, voltage bounds and random
-seed【F:daqio/daqO.py†L1-L13】【F:daqio/daqO.py†L33-L48】.
+seed【F:daqio/daqO.py†L1-L16】【F:daqio/daqO.py†L39-L55】.
+Always source these values from the `daqO` section; using `daqI` data for outputs
+can raise NI‑DAQmx `I/O type` errors or drive unintended channels.
 
 Example configuration:
 

--- a/daqio/daqI.py
+++ b/daqio/daqI.py
@@ -2,7 +2,10 @@
 
 This module provides a convenience wrapper for reading voltages from
 multiple analog-input (AI) channels of a National Instruments device.
-Configuration is supplied through a YAML file.
+Configuration is supplied through a YAML file. The YAML data must contain
+a dedicated ``daqI`` section for AI channels only. Analog outputs belong
+in a separate ``daqO`` section; mixing them may raise NI-DAQmx ``I/O type``
+errors or drive unintended channels.
 
 Example YAML configuration::
 

--- a/daqio/daqO.py
+++ b/daqio/daqO.py
@@ -1,9 +1,11 @@
 """Random analog-output helper for NI-DAQmx.
 
 This module provides utilities for driving one or more analog-output (AO)
-channels with random voltages.  Configuration may be supplied either
-programmatically or via a YAML file.  A small command-line interface is
-also provided::
+channels with random voltages. Configuration may be supplied either
+programmatically or via a YAML file. The configuration must come from a
+``daqO`` section; reusing ``daqI`` entries for outputs can trigger NI-DAQmx
+``I/O type`` errors or energize unintended channels. A small command-line
+interface is also provided::
 
     python -m daqio.daqO --config configs/config_test.yml
 


### PR DESCRIPTION
## Summary
- Explain that `daqI` and `daqO` configuration sections are distinct and must not be mixed.
- Highlight `IOasyncExample.py` as a pattern for loading the sections separately.
- Add warnings to `daqio` module docstrings about keeping analog input and output configs apart.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4df246b9483229a752112840eec78