### PR TITLE
Add omissions control to analog input reads

### DIFF
--- a/IOasyncExample.py
+++ b/IOasyncExample.py
@@ -20,7 +20,7 @@ async def ai_loop(cfg: dict):
     with setup_task(cfg) as task:
         while True:
             await asyncio.to_thread(read_average, task, cfg)
-            # read_average sleeps internally according to cfg["freq"]
+            # read_average sleeps internally according to cfg["freq"] and cfg["omissions"]
 
 
 async def queue_reader(q: asyncio.Queue, label: str):

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ each section separately when performing simultaneous input and output.
 
 `daqio/daqI.py` reads one or more analog-input channels and prints the average
 voltage per channel. Configuration is supplied via YAML and must define the
-device name, channel list, sample frequency and number of averages; the
-terminal configuration is optional【F:daqio/daqI.py†L1-L26】【F:daqio/daqI.py†L66-L74】.
+device name, channel list, sample frequency, number of averages and number of
+omitted intervals between reads; the terminal configuration is optional【F:daqio/daqI.py†L1-L26】【F:daqio/daqI.py†L66-L74】.
 Use only the `daqI` section for these settings; sourcing channel lists from
 `daqO` may cause NI‑DAQmx `I/O type` errors or unintended output.
 
@@ -105,6 +105,7 @@ daqI:
     - Dev1/ai1
   freq: 10
   averages: 5
+  omissions: 0
   terminal: RSE
 ```
 

--- a/configs/config_test.yml
+++ b/configs/config_test.yml
@@ -5,6 +5,7 @@ daqI:
     - Dev1/ai1
   freq: 10
   averages: 5
+  omissions: 0
   terminal: RSE
 daqO:
   device: cDAQ1Mod1

--- a/tests/test_publisher_ai.py
+++ b/tests/test_publisher_ai.py
@@ -48,7 +48,7 @@ def test_read_average_publish(monkeypatch):
         daqI, "load_output_config", lambda path: ("%Y", "out.csv", ["timestamp", "c1", "c2"])
     )
     monkeypatch.setattr(daqI.time, "sleep", lambda s: None)
-    cfg = {"freq": 1.0, "averages": 1, "channels": ["c1", "c2"]}
+    cfg = {"freq": 1.0, "averages": 1, "omissions": 0, "channels": ["c1", "c2"]}
     task = DummyTask([1.0, 2.0])
     read_average(task, cfg)
     assert captured["data"]["results"] == {"c1": 1.0, "c2": 2.0}


### PR DESCRIPTION
## Summary
- track omission intervals in analog-input Config and require the field in YAML
- support `--omissions` CLI flag and honor it when delaying between reads
- document the new setting and update configs/tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4e672ddc48322b65ce402541d346e