### PR TITLE
Document mandatory omissions config for analog input

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ each section separately when performing simultaneous input and output.
 
 `daqio/daqI.py` reads one or more analog-input channels and prints the average
 voltage per channel. Configuration is supplied via YAML and must define the
-device name, channel list, sample frequency, number of averages and number of
-omitted intervals between reads; the terminal configuration is optional【F:daqio/daqI.py†L1-L26】【F:daqio/daqI.py†L66-L74】.
+device name, channel list, sample frequency, number of averages, and the number
+of omitted intervals between reads. Omitting the `omissions` field raises a
+configuration error. The terminal configuration is optional【F:daqio/daqI.py†L1-L26】【F:daqio/daqI.py†L66-L74】.
 Use only the `daqI` section for these settings; sourcing channel lists from
 `daqO` may cause NI‑DAQmx `I/O type` errors or unintended output.
 
@@ -105,7 +106,7 @@ daqI:
     - Dev1/ai1
   freq: 10
   averages: 5
-  omissions: 0
+  omissions: 0  # number of sample intervals to skip between reads
   terminal: RSE
 ```
 

--- a/configs/config_test.yml
+++ b/configs/config_test.yml
@@ -5,7 +5,7 @@ daqI:
     - Dev1/ai1
   freq: 10
   averages: 5
-  omissions: 0
+  omissions: 0  # number of sample intervals to skip between reads
   terminal: RSE
 daqO:
   device: cDAQ1Mod1


### PR DESCRIPTION
## Summary
- Document that `daqI` configurations require an `omissions` field and show it in sample YAML
- Clarify how `omissions` determines skipped sample intervals in the default config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4e7cde81c832299059e46da5da0a6