### PR TITLE
docs: update script paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ PhantomTest provides a minimal test harness for verifying connectivity to a vari
 
 ## Repository layout
 
-* `test_daqs.py` – imports DAQ vendor libraries (LabJack LJM, MCC UL, NI‑DAQmx) and reports whether each module is available.
-* `test_nidaqmx_devices.py` – enumerates NI‑DAQmx devices and prints the name and product type of each detected device.
-* `test_device_names.py` – lists device names and product types using the NI‑DAQmx Python API.
+* `tests/test_daqs.py` – imports DAQ vendor libraries (LabJack LJM, MCC UL, NI‑DAQmx) and reports whether each module is available.
+* `tests/test_nidaqmx_devices.py` – enumerates NI‑DAQmx devices and prints the name and product type of each detected device.
+* `tests/test_device_names.py` – lists device names and product types using the NI‑DAQmx Python API.
 * `test_ai_all.py` – reads all analog input channels on a specified NI device, averaging a given number of samples at a specified frequency.
+* `test_ao_random.py` – drives analog-output channels with random voltages within a user-specified range.
 * `requirements.txt` – Python dependencies needed for the scripts.
 * `configs/` – sample YAML configuration files.
 
@@ -37,19 +38,19 @@ Execute the scripts from the repository root:
 * Detect available drivers:
 
    ```bash
-   python test_daqs.py
+   pytest tests/test_daqs.py
    ```
 
 * List NI‑DAQmx devices:
 
    ```bash
-   python test_nidaqmx_devices.py
+   pytest tests/test_nidaqmx_devices.py
    ```
 
 * Print device names and types:
 
    ```bash
-   python test_device_names.py
+   pytest tests/test_device_names.py
    ```
 
 * Sample analog inputs from all channels on a device:
@@ -58,7 +59,13 @@ Execute the scripts from the repository root:
    python test_ai_all.py --dev <DEVICE_NAME> --freq <Hz> --n <samples>
    ```
 
-The scripts will report the detected hardware or analog input readings.
+* Drive analog outputs with random voltages:
+
+   ```bash
+   python test_ao_random.py --dev <DEVICE_NAME> --interval <s> [--low <V>] [--high <V>]
+   ```
+
+The scripts will report the detected hardware, analog input readings or output activity.
 
 ## Running tests
 


### PR DESCRIPTION
## Summary
- correct README script paths to match repository structure
- add instructions for analog output script

## Testing
- `pytest tests/test_daqs.py tests/test_nidaqmx_devices.py tests/test_device_names.py`
- `python test_ai_all.py --help`
- `python test_ao_random.py --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4ec13547083228bf68f00d657aa84