### PR TITLE
Add device listing script and CLI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PhantomTest provides a minimal test harness for verifying connectivity to a vari
 ## Repository layout
 
 * `test_daqs.py` – imports DAQ vendor libraries (LabJack LJM, MCC UL, NI‑DAQmx) and reports whether each module is available.
-* `test_nidaqmx_devices.py` – enumerates NI‑DAQmx devices and prints the name and product type of each detected device.
+* `list_devices.py` – enumerates NI‑DAQmx devices and prints the name and product type of each detected device.
 * `test_device_names.py` – lists device names and product types using the NI‑DAQmx Python API.
 * `test_ai_all.py` – reads all analog input channels on a specified NI device, averaging a given number of samples at a specified frequency.
 * `requirements.txt` – Python dependencies needed for the scripts.
@@ -43,7 +43,7 @@ Execute the scripts from the repository root:
 * List NI‑DAQmx devices:
 
    ```bash
-   python test_nidaqmx_devices.py
+   python list_devices.py
    ```
 
 * Print device names and types:

--- a/list_devices.py
+++ b/list_devices.py
@@ -1,0 +1,32 @@
+"""List NI-DAQmx device names and product types."""
+
+from __future__ import annotations
+
+from daqio.config import list_devices
+
+try:  # pragma: no cover - nidaqmx is optional
+    from nidaqmx.system import System
+except Exception:  # noqa: BLE001 - best effort
+    System = None  # type: ignore[assignment]
+
+
+def main() -> None:
+    """Print each detected NI-DAQmx device and its product type."""
+
+    names = list_devices()
+    if not names or System is None:
+        print("No NI-DAQmx devices detected.")
+        return
+
+    try:
+        system = System.local()
+    except Exception as exc:  # noqa: BLE001 - best effort
+        print(f"NI-DAQmx system unavailable: {exc}")
+        return
+
+    for device in system.devices:
+        print(f"{device.name}: {device.product_type}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,8 @@ dependencies = ["nidaqmx", "pyyaml"]
 [project.optional-dependencies]
 test = ["pytest"]
 
+[project.scripts]
+list-devices = "list_devices:main"
+
 [tool.setuptools.packages.find]
 include = ["daqio"]


### PR DESCRIPTION
## Summary
- add `list_devices.py` script to print NI-DAQmx device names and product types
- document the new script and usage in README
- expose the script as a `list-devices` console entry point

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4ed015c008322a5a30424149a2441