### PR TITLE
Add script to list NI-DAQmx devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Execute the scripts from the repository root:
    pytest tests/test_device_names.py
    ```
 
+* List device names and product types with a helper script:
+
+   ```bash
+   python list_devices.py
+   ```
+
 * Sample analog inputs from all channels on a device:
 
    ```bash

--- a/list_devices.py
+++ b/list_devices.py
@@ -1,0 +1,29 @@
+"""List NI-DAQmx devices and their product types."""
+
+from __future__ import annotations
+
+from daqio.config import list_devices
+
+try:  # pragma: no cover - nidaqmx may be unavailable
+    from nidaqmx.system import System
+except Exception:  # noqa: BLE001 - optional dependency
+    System = None  # type: ignore[assignment]
+
+
+def main() -> None:
+    """Print each detected device name and its product type."""
+    if System is None:
+        print("nidaqmx not available.")
+        return
+    try:
+        system = System.local()
+    except Exception:  # noqa: BLE001 - best effort system access
+        print("NI-DAQmx system unavailable.")
+        return
+    for name in list_devices():
+        product_type = system.devices[name].product_type
+        print(f"{name}: {product_type}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,11 @@ dependencies = ["nidaqmx", "pyyaml"]
 [project.optional-dependencies]
 test = ["pytest"]
 
+[project.scripts]
+list-devices = "list_devices:main"
+
+[tool.setuptools]
+py-modules = ["list_devices"]
+
 [tool.setuptools.packages.find]
 include = ["daqio"]


### PR DESCRIPTION
## Summary
- add list_devices.py script to display NI-DAQmx device names and product types
- document new script and expose `list-devices` console command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4edcb2680832282b1076aab1a5090