### PR TITLE
docs: add module docstring to publisher

### DIFF
--- a/daqio/publisher.py
+++ b/daqio/publisher.py
@@ -1,3 +1,7 @@
+"""Manage queues and CSV writers for analog I/O.
+
+Public API: publish_ao, publish_ai, start_ao_consumer, start_ai_consumer.
+"""
 import asyncio
 from pathlib import Path
 import csv


### PR DESCRIPTION
## Summary
- add module docstring to publisher clarifying queue and CSV management for analog I/O

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4f52fe5c48322ae4fc04344f1cd84