### PR TITLE
Add pytest-asyncio to test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.8"
 dependencies = ["nidaqmx", "pyyaml"]
 
 [project.optional-dependencies]
-test = ["pytest"]
+test = ["pytest", "pytest-asyncio"]
 
 [project.scripts]
 list-devices = "list_devices:main"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
+pytest-asyncio
 


### PR DESCRIPTION
## Summary
- include pytest-asyncio in dev requirements and test extra dependencies

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .[test]`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c600d4f5948322b719258f5ed9801b