### PR TITLE
Enable standalone execution of waveform I/O test

### DIFF
--- a/tests/test_waveform_io.py
+++ b/tests/test_waveform_io.py
@@ -99,3 +99,7 @@ async def test_waveform_io():
                 for t in tasks:
                     t.cancel()
                 await asyncio.gather(*tasks, return_exceptions=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(test_waveform_io())


### PR DESCRIPTION
## Summary
- allow `tests/test_waveform_io.py` to be run directly by adding an `asyncio.run` entry point

## Testing
- `pytest tests/test_waveform_io.py` (skipped: NI-DAQmx system unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68c600e5113c83228b55f91bc7a6802f