### PR TITLE
Publish read_once values to AI queue

### DIFF
--- a/daqio/ai_reader.py
+++ b/daqio/ai_reader.py
@@ -139,7 +139,16 @@ class AIReader:
         vals = self._task.read()
         if not isinstance(vals, list):
             vals = [vals]
-        return dict(zip(self.cfg.channels, vals))
+        result = dict(zip(self.cfg.channels, vals))
+
+        # Optionally publish the single-shot result
+        if self.publish:
+            ts_format = self._resolve_time_format(use_output_yaml=False)
+            ts_pub = datetime.now().strftime(ts_format)
+            payload = {"timestamp": ts_pub, "results": result}
+            self._publish_now(payload)
+
+        return result
 
     def read_average(
         self,

--- a/tests/test_ai_reader_read_once.py
+++ b/tests/test_ai_reader_read_once.py
@@ -1,0 +1,40 @@
+"""Tests for :mod:`daqio.ai_reader` single-shot acquisition publishing."""
+
+from __future__ import annotations
+
+from daqio.ai_reader import AIReader
+
+
+class DummyTask:
+    """Minimal task stub returning pre-defined values."""
+
+    def __init__(self, values):
+        self._values = values
+
+    def read(self):  # noqa: D401 - simple stub
+        return self._values
+
+
+def test_read_once_publish():
+    captured: dict = {}
+
+    async def fake_publish(data):
+        captured["data"] = data
+
+    reader = AIReader(
+        device="Dev1",
+        channels=["c1", "c2"],
+        freq=1.0,
+        averages=1,
+        omissions=0,
+        publish=fake_publish,
+    )
+    reader._task = DummyTask([1.0, 2.0])  # type: ignore[assignment]
+    reader._open = True
+
+    results = reader.read_once()
+
+    assert results == {"c1": 1.0, "c2": 2.0}
+    assert captured["data"]["results"] == {"c1": 1.0, "c2": 2.0}
+    assert captured["data"]["timestamp"]
+


### PR DESCRIPTION
## Summary
- publish AIReader `read_once` results to AI queue with timestamped payload
- cover `read_once` publishing path with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c60999601483229c56e18bffb086b6