### PR TITLE
Simplify AO waveform publish payload

### DIFF
--- a/daqio/ao_runner.py
+++ b/daqio/ao_runner.py
@@ -225,8 +225,6 @@ class AsyncAORunner:
                 ts = datetime.now().strftime(self.time_format)
                 payload = {
                     "timestamp": ts,
-                    "sample_index": int(idx),
-                    "cycle_index": int(cycle_count),
                     "channel_values": dict(zip(self._ao_ch_names, row.tolist())),
                 }
                 await self.publish(payload)


### PR DESCRIPTION
## Summary
- Remove sample and cycle indices from `AsyncAORunner` waveform publish payload so printed AO messages only show timestamp and channel values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c60d89910c83229be0c71185847f54