### PR TITLE
Use channel_values for analog input payloads

### DIFF
--- a/IOasyncExample.py
+++ b/IOasyncExample.py
@@ -16,7 +16,7 @@ from daqio import publisher
 
 
 async def ai_loop(cfg: dict):
-    """Continuously read analog inputs and publish results."""
+    """Continuously read analog inputs and publish channel values."""
     with setup_task(cfg) as task:
         while True:
             await asyncio.to_thread(read_average, task, cfg)

--- a/IOasyncInteractive.py
+++ b/IOasyncInteractive.py
@@ -1,7 +1,7 @@
 """Interactive asynchronous analog I/O demo with keypress exit.
 
 Continuously writes random analog outputs while reading analog inputs and
-publishing results. Press Enter to stop the demo gracefully.
+publishing channel values. Press Enter to stop the demo gracefully.
 """
 
 import asyncio

--- a/daqio/ai_reader.py
+++ b/daqio/ai_reader.py
@@ -37,7 +37,7 @@ class AIReader:
     Usage:
         reader = AIReader.from_yaml("configs/config_test.yml")
         with reader:  # opens task
-            results, log = reader.read_average()
+            channel_values, log = reader.read_average()
     """
 
     def __init__(
@@ -145,7 +145,7 @@ class AIReader:
         if self.publish:
             ts_format = self._resolve_time_format(use_output_yaml=False)
             ts_pub = datetime.now().strftime(ts_format)
-            payload = {"timestamp": ts_pub, "results": result}
+            payload = {"timestamp": ts_pub, "channel_values": result}
             self._publish_now(payload)
 
         return result
@@ -159,7 +159,7 @@ class AIReader:
         Collect `averages` samples at 1/freq, skipping `omissions` intervals between reads.
         Prints each read with a high-res timestamp.
         Returns:
-            results: {channel: mean_voltage}
+            channel_values: {channel: mean_voltage}
             log:     [{"timestamp": ts, "values": {...}}, ...] for each read
         Also publishes a summary payload once (if `publish` set).
         """
@@ -186,17 +186,17 @@ class AIReader:
 
         arr = np.asarray(batch, dtype=float)
         means = np.nanmean(arr, axis=0)
-        results = dict(zip(self.cfg.channels, means))
-        for ch, val in results.items():
+        channel_values = dict(zip(self.cfg.channels, means))
+        for ch, val in channel_values.items():
             print(f"{ch}: {val:.6f} V")
 
         # Publish once per batch (optional)
         if self.publish:
             ts_pub = datetime.now().strftime(ts_format)
-            payload = {"timestamp": ts_pub, "results": results}
+            payload = {"timestamp": ts_pub, "channel_values": channel_values}
             self._publish_now(payload)
 
-        return results, log
+        return channel_values, log
 
     # ---------- Utilities ----------
     def _resolve_time_format(self, use_output_yaml: bool) -> str:

--- a/daqio/daqI.py
+++ b/daqio/daqI.py
@@ -23,7 +23,7 @@ Run the module from the command line::
     python -m daqio.daqI --config configs/config_test.yml
 
 The script will acquire the requested number of samples from each
-channel, compute the mean voltage per channel and print the results.
+channel, compute the mean voltage per channel and print the channel values.
 """
 
 from __future__ import annotations
@@ -241,12 +241,12 @@ def read_average(
     arr = np.asarray(batch, dtype=float)
     means = np.nanmean(arr, axis=0)
 
-    results = dict(zip(config["channels"], means))
-    for ch, val in results.items():
+    channel_values = dict(zip(config["channels"], means))
+    for ch, val in channel_values.items():
         print(f"{ch}: {val:.6f} V")
 
     ts = datetime.now().strftime(ts_format)
-    payload = {"timestamp": ts, "results": results}
+    payload = {"timestamp": ts, "channel_values": channel_values}
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
@@ -254,7 +254,7 @@ def read_average(
     else:
         loop.create_task(publish_ai(payload))
 
-    return results, log
+    return channel_values, log
 
 
 # ---------------------------------------------------------------------------

--- a/daqio/publisher.py
+++ b/daqio/publisher.py
@@ -66,11 +66,11 @@ async def publish_ao(data: Dict) -> None:
     await _put_drop_oldest(_get_ao_queue(), data)
 
 
-async def publish_ai(result: Dict) -> None:
-    """Publish analog-input averaging results to the queue and update latest snapshot."""
+async def publish_ai(data: Dict) -> None:
+    """Publish analog-input channel values to the queue and update latest snapshot."""
     global _latest_ai
-    _latest_ai = result
-    await _put_drop_oldest(_get_ai_queue(), result)
+    _latest_ai = data
+    await _put_drop_oldest(_get_ai_queue(), data)
 
 
 async def _ao_consumer(csv_path: str, columns: List[str]) -> None:
@@ -107,7 +107,7 @@ async def _ai_consumer(csv_path: str, columns: List[str]) -> None:
                 if col == "timestamp":
                     row[col] = item.get("timestamp")
                 else:
-                    row[col] = item.get("results", {}).get(col)
+                    row[col] = item.get("channel_values", {}).get(col)
             writer.writerow(row)
             fh.flush()
             queue.task_done()

--- a/tests/test_ai_reader_read_once.py
+++ b/tests/test_ai_reader_read_once.py
@@ -32,9 +32,9 @@ def test_read_once_publish():
     reader._task = DummyTask([1.0, 2.0])  # type: ignore[assignment]
     reader._open = True
 
-    results = reader.read_once()
+    channel_values = reader.read_once()
 
-    assert results == {"c1": 1.0, "c2": 2.0}
-    assert captured["data"]["results"] == {"c1": 1.0, "c2": 2.0}
+    assert channel_values == {"c1": 1.0, "c2": 2.0}
+    assert captured["data"]["channel_values"] == {"c1": 1.0, "c2": 2.0}
     assert captured["data"]["timestamp"]
 

--- a/tests/test_publisher_ai.py
+++ b/tests/test_publisher_ai.py
@@ -13,7 +13,7 @@ async def _run_consumer(tmp_path: Path):
     csv_file = tmp_path / "ai.csv"
     columns = ["timestamp", "c1", "c2"]
     task = publisher.start_ai_consumer(str(csv_file), columns)
-    payload = {"timestamp": "t0", "results": {"c1": 1, "c2": 2}}
+    payload = {"timestamp": "t0", "channel_values": {"c1": 1, "c2": 2}}
     await publisher.publish_ai(payload)
     await publisher._get_ai_queue().join()
     task.cancel()
@@ -51,5 +51,5 @@ def test_read_average_publish(monkeypatch):
     cfg = {"freq": 1.0, "averages": 1, "omissions": 0, "channels": ["c1", "c2"]}
     task = DummyTask([1.0, 2.0])
     read_average(task, cfg)
-    assert captured["data"]["results"] == {"c1": 1.0, "c2": 2.0}
+    assert captured["data"]["channel_values"] == {"c1": 1.0, "c2": 2.0}
     assert captured["data"]["timestamp"].isdigit()


### PR DESCRIPTION
## Summary
- replace all analog-input payload keys `results` with `channel_values`
- adapt publisher consumers and tests to read `channel_values`
- document channel value publishing in async demos

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6194604f08322bc0356c937a15678