### PR TITLE
Convert averaged AI readings to native floats

### DIFF
--- a/daqio/daqI.py
+++ b/daqio/daqI.py
@@ -241,7 +241,7 @@ def read_average(
     arr = np.asarray(batch, dtype=float)
     means = np.nanmean(arr, axis=0)
 
-    channel_values = dict(zip(config["channels"], means))
+    channel_values = {ch: float(val) for ch, val in zip(config["channels"], means)}
     for ch, val in channel_values.items():
         print(f"{ch}: {val:.6f} V")
 


### PR DESCRIPTION
## Summary
- ensure `read_average` returns Python `float` values for channel means

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c62097ee288322b437f9a7f88c220b