### PR TITLE
Use channel_values in read_average log

### DIFF
--- a/daqio/daqI.py
+++ b/daqio/daqI.py
@@ -214,7 +214,9 @@ def read_average(
     -------
     tuple of (dict, list of dict)
         Mapping of channel names to mean voltages in volts and a list of
-        timestamped sample readings for optional post-processing.
+        timestamped sample readings for optional post-processing. Each log
+        entry contains a ``timestamp`` and ``channel_values`` mapping channels
+        to floating-point voltages.
     """
 
     cfg_path = (
@@ -234,7 +236,12 @@ def read_average(
             vals = [vals]
         for ch, val in zip(config["channels"], vals):
             print(f"{ts} {ch}: {val:.6f} V")
-        log.append({"timestamp": ts, "values": dict(zip(config["channels"], vals))})
+        log.append(
+            {
+                "timestamp": ts,
+                "channel_values": {ch: float(val) for ch, val in zip(config["channels"], vals)},
+            }
+        )
         batch.append(vals)
         time.sleep(sample_interval * (config["omissions"] + 1))
 

--- a/tests/test_publisher_ai.py
+++ b/tests/test_publisher_ai.py
@@ -50,6 +50,10 @@ def test_read_average_publish(monkeypatch):
     monkeypatch.setattr(daqI.time, "sleep", lambda s: None)
     cfg = {"freq": 1.0, "averages": 1, "omissions": 0, "channels": ["c1", "c2"]}
     task = DummyTask([1.0, 2.0])
-    read_average(task, cfg)
+    channel_values, log = read_average(task, cfg)
+    assert channel_values == {"c1": 1.0, "c2": 2.0}
     assert captured["data"]["channel_values"] == {"c1": 1.0, "c2": 2.0}
     assert captured["data"]["timestamp"].isdigit()
+    assert log[0]["channel_values"] == {"c1": 1.0, "c2": 2.0}
+    for val in log[0]["channel_values"].values():
+        assert isinstance(val, float)


### PR DESCRIPTION
## Summary
- log channel readings under `channel_values` and cast values to float in `read_average`
- verify log entries in `test_read_average_publish`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c62cbcd9a4832288e21d6daa74784f