### PR TITLE
Ensure analog output data uses native floats

### DIFF
--- a/daqio/ao_runner.py
+++ b/daqio/ao_runner.py
@@ -206,7 +206,13 @@ class AsyncAORunner:
             self._task.write(values)
             if self.publish:
                 ts = datetime.now().strftime(self.time_format)
-                payload = {"timestamp": ts, "channel_values": dict(zip(self._ao_ch_names, values))}
+                # Cast each value to a native Python float for downstream consumers
+                payload = {
+                    "timestamp": ts,
+                    "channel_values": {
+                        ch: float(v) for ch, v in zip(self._ao_ch_names, values)
+                    },
+                }
                 await self.publish(payload)
             await asyncio.sleep(self.interval)
 
@@ -223,9 +229,12 @@ class AsyncAORunner:
 
             if self.publish:
                 ts = datetime.now().strftime(self.time_format)
+                # Convert per-channel samples to native floats before publishing
                 payload = {
                     "timestamp": ts,
-                    "channel_values": dict(zip(self._ao_ch_names, row.tolist())),
+                    "channel_values": {
+                        ch: float(v) for ch, v in zip(self._ao_ch_names, row.tolist())
+                    },
                 }
                 await self.publish(payload)
 

--- a/daqio/daqO.py
+++ b/daqio/daqO.py
@@ -160,7 +160,8 @@ async def write_random(
                 ts = datetime.now().strftime(ts_format)
                 payload = {
                     "timestamp": ts,
-                    "channel_values": {c: v for c, v in zip(ao_channels, values)},
+                    # Ensure downstream consumers receive plain Python floats
+                    "channel_values": {c: float(v) for c, v in zip(ao_channels, values)},
                 }
                 await publish_ao(payload)
                 await asyncio.sleep(interval)


### PR DESCRIPTION
## Summary
- Cast analog output values to `float` before publishing in `daqO.write_random`
- Cast values to `float` in `AsyncAORunner` for both random and waveform modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c62d676f248322a162a8b852aea7b3