### PR TITLE
Register pytest-asyncio plugin for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,6 @@ py-modules = ["list_devices"]
 
 [tool.setuptools.packages.find]
 include = ["daqio"]
+
+[tool.pytest.ini_options]
+addopts = "-p pytest_asyncio"


### PR DESCRIPTION
## Summary
- register pytest-asyncio in pytest addopts

## Testing
- `pytest tests/test_waveform_io.py`

------
https://chatgpt.com/codex/tasks/task_e_68c6422fa90c8322be7965a980624536