### PR TITLE
Use logging for analog input diagnostics

### DIFF
--- a/IOasyncExample.py
+++ b/IOasyncExample.py
@@ -8,6 +8,7 @@ equipment.  Always use the ``daqO`` section for any AO tasks.
 """
 
 import asyncio
+import logging
 
 from daqio.daqO import write_random
 from daqio.daqI import load_config as load_ai_config, setup_task, read_average
@@ -62,4 +63,5 @@ async def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     asyncio.run(main())

--- a/daqio/daqI.py
+++ b/daqio/daqI.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import logging
 import time
 from datetime import datetime
 from dataclasses import dataclass
@@ -46,6 +47,8 @@ from .config import (
     load_output_config,
 )
 from .publisher import publish_ai
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -235,7 +238,7 @@ def read_average(
         if not isinstance(vals, list):
             vals = [vals]
         for ch, val in zip(config["channels"], vals):
-            print(f"{ts} {ch}: {val:.6f} V")
+            logger.debug(f"{ts} {ch}: {val:.6f} V")
         log.append(
             {
                 "timestamp": ts,
@@ -250,7 +253,7 @@ def read_average(
 
     channel_values = {ch: float(val) for ch, val in zip(config["channels"], means)}
     for ch, val in channel_values.items():
-        print(f"{ch}: {val:.6f} V")
+        logger.info(f"{ch}: {val:.6f} V")
 
     ts = datetime.now().strftime(ts_format)
     payload = {"timestamp": ts, "channel_values": channel_values}
@@ -272,6 +275,7 @@ def read_average(
 def main(argv: Optional[Iterable[str]] = None) -> Dict[str, Any]:
     """Command-line entry point."""
 
+    logging.basicConfig(level=logging.INFO)
     cfg = parse_args_with_config("configs/config_test.yml", argv=argv)
     with setup_task(cfg) as task:
         read_average(task, cfg)


### PR DESCRIPTION
## Summary
- Replace print statements in `daqio.daqI` with `logging` calls
- Configure logging level in example application

## Testing
- `PYTHONPATH=. pytest tests/test_publisher_ai.py tests/test_daqo_config.py tests/test_device_names.py tests/test_ai_reader_read_once.symmetric? Wait we wrote earlier? Should put final command. Let's check: tests/test_daqs.py tests/test_nidaqmx_devices.py -q`
- `PYTHONPATH=. pytest tests/test_waveform_io.py -q` *(fails: NI-DAQmx system unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c74abb63208322831744c1bfa36cf0