### PR TITLE
Optimize sample timing and logging

### DIFF
--- a/tests/test_publisher_ai.py
+++ b/tests/test_publisher_ai.py
@@ -50,7 +50,7 @@ def test_read_average_publish(monkeypatch):
     monkeypatch.setattr(daqI.time, "sleep", lambda s: None)
     cfg = {"freq": 1.0, "averages": 1, "omissions": 0, "channels": ["c1", "c2"]}
     task = DummyTask([1.0, 2.0])
-    channel_values, log = read_average(task, cfg)
+    channel_values, log = read_average(task, cfg, log_samples=True)
     assert channel_values == {"c1": 1.0, "c2": 2.0}
     assert captured["data"]["channel_values"] == {"c1": 1.0, "c2": 2.0}
     assert captured["data"]["timestamp"].isdigit()


### PR DESCRIPTION
## Summary
- avoid per-sample timestamp formatting unless logging is requested
- accumulate running means to reduce memory overhead
- allow optional sample logs and update tests accordingly

## Testing
- `PYTEST_CURRENT_TEST=1 PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74e07e5d48322a56efe3e61ab8d1e