### PR TITLE
Add capture filename parsing utility and summary logging

### DIFF
--- a/capture_filename.py
+++ b/capture_filename.py
@@ -1,0 +1,110 @@
+"""Utilities for parsing Pico capture filenames."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+__all__ = ["CaptureFilenameMetadata", "parse_capture_filename"]
+
+
+@dataclass(frozen=True)
+class CaptureFilenameMetadata:
+    """Structured information parsed from a capture filename.
+
+    Attributes
+    ----------
+    timestamp:
+        The hardware timestamp embedded in the filename.
+    channels:
+        Mapping of channel names to their recorded floating point values.
+    stem:
+        The stem portion of the filename (without extension).
+    extension:
+        The file extension including the leading dot.
+    """
+
+    timestamp: datetime
+    channels: Dict[str, float]
+    stem: str
+    extension: str
+
+
+_CAPTURE_FILENAME_RE = re.compile(
+    r"""
+    ^
+    (?P<stem>.+?)
+    __
+    (?P<hwts>\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}(?:\.\d+)?)
+    (?P<channel_suffix>(?:__[A-Za-z0-9]+_-?[0-9]+(?:p[0-9]+)?)*)
+    (?P<extension>\.[A-Za-z0-9]+)
+    $
+    """,
+    re.VERBOSE,
+)
+
+_CHANNEL_RE = re.compile(r"__([A-Za-z0-9]+)_(-?[0-9]+(?:p[0-9]+)?)")
+
+
+def _value_to_float(raw: str) -> float:
+    """Convert a DAQ channel value token into a float."""
+    normalized = raw.replace("p", ".")
+    try:
+        return float(normalized)
+    except ValueError as exc:  # pragma: no cover - defensive, should not happen with regex
+        raise ValueError(f"Invalid channel value token: {raw!r}") from exc
+
+
+def parse_capture_filename(filename: str | Path) -> CaptureFilenameMetadata:
+    """Parse a capture filename and extract timestamp/channel metadata.
+
+    Parameters
+    ----------
+    filename:
+        Filename or path to parse. The parent directories are ignored; only the
+        final path component is inspected.
+
+    Returns
+    -------
+    CaptureFilenameMetadata
+        Parsed timestamp and channel mapping information.
+
+    Raises
+    ------
+    ValueError
+        If the filename does not conform to the expected capture pattern.
+    """
+
+    name = Path(filename).name
+    match = _CAPTURE_FILENAME_RE.match(name)
+    if not match:
+        raise ValueError(f"Unrecognised capture filename format: {name!r}")
+
+    hwts = match.group("hwts")
+    timestamp: datetime
+    for fmt in ("%Y-%m-%d-%H-%M-%S.%f", "%Y-%m-%d-%H-%M-%S"):
+        try:
+            timestamp = datetime.strptime(hwts, fmt)
+            break
+        except ValueError:
+            continue
+    else:  # pragma: no cover - regex should enforce correctness
+        raise ValueError(f"Invalid timestamp token in capture filename: {hwts!r}")
+
+    channel_suffix = match.group("channel_suffix")
+    channels: Dict[str, float] = {}
+    if channel_suffix:
+        for channel_match in _CHANNEL_RE.finditer(channel_suffix):
+            channel, raw_value = channel_match.groups()
+            channels[channel] = _value_to_float(raw_value)
+
+    stem = f"{match.group('stem')}__{hwts}"
+    extension = match.group("extension")
+    return CaptureFilenameMetadata(
+        timestamp=timestamp,
+        channels=channels,
+        stem=stem,
+        extension=extension,
+    )

--- a/scripts/run_waveform_and_pico_capture.py
+++ b/scripts/run_waveform_and_pico_capture.py
@@ -25,7 +25,7 @@ import signal
 import sys
 import threading
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional, Set
 
 import numpy as np
 
@@ -39,6 +39,8 @@ from daqio import publisher
 from daqio.ao_runner import AsyncAORunner
 from daqio.ai_reader import AIReader
 from daqio.config import load_yaml
+
+from capture_filename import parse_capture_filename
 
 
 # -----------------------
@@ -105,12 +107,44 @@ def _load_module_from_path(module_name: str, file_path: Path):
     return mod
 
 
+def _list_capture_files(outdir: Path) -> Set[Path]:
+    patterns: Iterable[str] = ("*.npz", "*.csv")
+    files: Set[Path] = set()
+    for pattern in patterns:
+        files.update(outdir.glob(pattern))
+    return files
+
+
+def _log_capture_summary(paths: Iterable[Path]) -> None:
+    for path in sorted(paths):
+        try:
+            metadata = parse_capture_filename(path.name)
+        except ValueError as exc:
+            print(f"[capture] Skipping unrecognised file {path.name}: {exc}")
+            continue
+
+        timestamp_str = metadata.timestamp.isoformat()
+        if metadata.channels:
+            channel_parts = [
+                f"{channel}={value:.3f}"
+                for channel, value in sorted(metadata.channels.items())
+            ]
+            channels_repr = ", ".join(channel_parts)
+        else:
+            channels_repr = "<no channel data>"
+
+        print(
+            f"[capture] Parsed {path.name} | timestamp={timestamp_str} | channels: {channels_repr}"
+        )
+
+
 async def capture_loop(args, outdir: Path, stop_evt: asyncio.Event) -> None:
     """Run Pico capture (multi-shot preferred) without blocking the event loop."""
     if stop_evt.is_set():
         return
 
     did_capture = False
+    known_files = _list_capture_files(outdir)
 
     multi_py_path: Optional[Path] = None
     if args.multi_py:
@@ -155,6 +189,9 @@ async def capture_loop(args, outdir: Path, stop_evt: asyncio.Event) -> None:
             await asyncio.to_thread(multi_mod.main, multi_cfg)
             did_capture = True
             print("[ok] Multi-shot capture phase complete.")
+            new_files = _list_capture_files(outdir) - known_files
+            _log_capture_summary(new_files)
+            known_files |= new_files
         except Exception as e:
             print(f"[warning] Multi-shot capture failed: {e}")
 
@@ -181,6 +218,9 @@ async def capture_loop(args, outdir: Path, stop_evt: asyncio.Event) -> None:
                     return
                 await asyncio.to_thread(cap_mod.main, cap_cfg)
                 print("[ok] Pico single-shot capture complete.")
+                new_files = _list_capture_files(outdir) - known_files
+                _log_capture_summary(new_files)
+                known_files |= new_files
             except Exception as e:
                 print(f"[warning] Pico single-shot capture failed: {e}")
 

--- a/tests/test_capture_filename.py
+++ b/tests/test_capture_filename.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from capture_filename import parse_capture_filename
+
+
+@pytest.mark.parametrize(
+    "filename, expected_ts, expected_channels",
+    [
+        (
+            "M09-D19-H09-M47-S43-U.098__2025-09-19-09-47-43.057497__ai1_3p698__ai2_5p005__ai3_3p789.npz",
+            datetime(2025, 9, 19, 9, 47, 43, 57497),
+            {"ai1": 3.698, "ai2": 5.005, "ai3": 3.789},
+        ),
+        (
+            "prefix__2024-01-02-03-04-05.6__ai0_-1p500__ai12_0p000.csv",
+            datetime(2024, 1, 2, 3, 4, 5, 600000),
+            {"ai0": -1.5, "ai12": 0.0},
+        ),
+        (
+            "abc__2023-07-08-09-10-11__ai1_3.npz",
+            datetime(2023, 7, 8, 9, 10, 11),
+            {"ai1": 3.0},
+        ),
+    ],
+)
+def test_parse_capture_filename(filename, expected_ts, expected_channels):
+    metadata = parse_capture_filename(filename)
+    assert metadata.timestamp == expected_ts
+    assert metadata.channels == expected_channels
+
+
+def test_parse_capture_filename_invalid():
+    with pytest.raises(ValueError):
+        parse_capture_filename("not_a_capture_file.txt")


### PR DESCRIPTION
## Summary
- add a reusable helper to parse capture filenames into timestamp and channel metadata
- update the Pico capture loop to summarise newly created files using the parsed data
- cover representative filename patterns with unit tests

## Testing
- pytest tests/test_capture_filename.py


------
https://chatgpt.com/codex/tasks/task_e_68d894151b08832287ac27b94c09bb33