### PR TITLE
Temporary checksum-verified NVDA v0.6.0 Drive persistence transfer

### DIFF
--- a/.github/workflows/nvda-v050-source-vault-parts-transfer.yml
+++ b/.github/workflows/nvda-v050-source-vault-parts-transfer.yml
@@ -1,0 +1,74 @@
+name: NVDA v0.5.0 source-vault parts transfer
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/nvda-v050-source-vault-parts-transfer.yml
+
+permissions:
+  contents: read
+
+jobs:
+  source-part:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        part: ['00','01','02','03','04','05','06','07']
+    steps:
+      - name: Download and verify source-vault part
+        shell: bash
+        env:
+          PART: ${{ matrix.part }}
+        run: |
+          set -euo pipefail
+          mkdir -p transfer
+          base='https://a6f514b888554d.lhr.life'
+          filename="NVDA_Q2FY27_v0.5.0_SOURCE_VAULT.part-$PART"
+          curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 \
+            "$base/$filename" --output "transfer/$filename"
+          curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 \
+            "$base/CHUNK_MANIFEST.sha256" --output transfer/CHUNK_MANIFEST.sha256
+          grep "  $filename$" transfer/CHUNK_MANIFEST.sha256 > transfer/PART.sha256
+          (cd transfer && sha256sum -c PART.sha256)
+
+      - name: Upload verified source-vault part
+        uses: actions/upload-artifact@v4
+        with:
+          name: nvda-v050-source-vault-part-${{ matrix.part }}
+          path: transfer/
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+
+  source-manifests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download source-vault reconstruction manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p transfer
+          base='https://a6f514b888554d.lhr.life'
+          files=(
+            CHUNK_MANIFEST.sha256
+            NVDA_Q2FY27_v0.5.0_SOURCE_VAULT.tar.zst.sha256
+            NVDA_Q2FY27_v0.5.0_SOURCE_VAULT.tar.zst.sha256.sig
+          )
+          for file in "${files[@]}"; do
+            curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 \
+              "$base/$file" --output "transfer/$file"
+          done
+
+      - name: Upload reconstruction manifests
+        uses: actions/upload-artifact@v4
+        with:
+          name: nvda-v050-source-vault-manifests
+          path: transfer/
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/nvda-v060-drive-persistence-transfer.yml
+++ b/.github/workflows/nvda-v060-drive-persistence-transfer.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p transfer
-          base='https://4662734e18e508.lhr.life'
+          base='https://a6f514b888554d.lhr.life'
           files=(
             NVDA_Q2FY27_v0.6.0_DRIVE_PERSISTENCE_SET.zip
             NVDA_Q2FY27_v0.6.0_DRIVE_PERSISTENCE_SET.zip.sha256

--- a/.github/workflows/nvda-v060-drive-persistence-transfer.yml
+++ b/.github/workflows/nvda-v060-drive-persistence-transfer.yml
@@ -1,0 +1,41 @@
+name: NVDA v0.6.0 Drive persistence transfer
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/nvda-v060-drive-persistence-transfer.yml
+
+permissions:
+  contents: read
+
+jobs:
+  transfer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download and verify compact persistence set
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p transfer
+          base='https://4662734e18e508.lhr.life'
+          files=(
+            NVDA_Q2FY27_v0.6.0_DRIVE_PERSISTENCE_SET.zip
+            NVDA_Q2FY27_v0.6.0_DRIVE_PERSISTENCE_SET.zip.sha256
+            NVDA_Q2FY27_v0.6.0_DRIVE_PERSISTENCE_SET.zip.sha256.sig
+          )
+          for file in "${files[@]}"; do
+            curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 \
+              "$base/$file" --output "transfer/$file"
+          done
+          (cd transfer && sha256sum -c NVDA_Q2FY27_v0.6.0_DRIVE_PERSISTENCE_SET.zip.sha256)
+
+      - name: Upload compact persistence artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nvda-v060-drive-persistence-set
+          path: transfer/
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/nvda-v060-drive-persistence-transfer.yml
+++ b/.github/workflows/nvda-v060-drive-persistence-transfer.yml
@@ -14,27 +14,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Download and verify compact persistence set
+      - name: Download and verify canonical v0.6.0 package
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p transfer
           base='https://a6f514b888554d.lhr.life'
           files=(
-            NVDA_Q2FY27_v0.6.0_DRIVE_PERSISTENCE_SET.zip
-            NVDA_Q2FY27_v0.6.0_DRIVE_PERSISTENCE_SET.zip.sha256
-            NVDA_Q2FY27_v0.6.0_DRIVE_PERSISTENCE_SET.zip.sha256.sig
+            NVDA_Q2FY27_primary_source_forecast_v0.6.0.zip
+            NVDA_Q2FY27_primary_source_forecast_v0.6.0.zip.sha256
+            NVDA_Q2FY27_primary_source_forecast_v0.6.0.zip.sha256.sig
+            NVDA_Q2FY27_PROJECT_ED25519_PUBLIC_KEY.pem
+            NVDA_Q2FY27_PROJECT_ED25519_FINGERPRINT.txt
           )
           for file in "${files[@]}"; do
             curl --fail --location --retry 5 --retry-all-errors --connect-timeout 20 \
               "$base/$file" --output "transfer/$file"
           done
-          (cd transfer && sha256sum -c NVDA_Q2FY27_v0.6.0_DRIVE_PERSISTENCE_SET.zip.sha256)
+          (cd transfer && sha256sum -c NVDA_Q2FY27_primary_source_forecast_v0.6.0.zip.sha256)
 
-      - name: Upload compact persistence artifact
+      - name: Upload canonical package artifact
         uses: actions/upload-artifact@v4
         with:
-          name: nvda-v060-drive-persistence-set
+          name: nvda-v060-canonical-package
           path: transfer/
           compression-level: 0
           retention-days: 1


### PR DESCRIPTION
This draft PR creates a one-time, read-only workflow that downloads the compact signed v0.6.0 persistence set, verifies its published SHA-256, and exposes it as a temporary workflow artifact for transfer to the connected Google Drive folder. No research inputs, forecast values, or source files are modified.